### PR TITLE
add support for typecast option to insert query

### DIFF
--- a/src/Airtable/Query/InsertQuery.php
+++ b/src/Airtable/Query/InsertQuery.php
@@ -13,10 +13,18 @@ class InsertQuery extends AbstractQuery
     /** @var Record[] */
     protected array $records = [];
 
+    protected bool $typecast = false;
+
     public function insert(Record ...$records): self
     {
         $this->records = $records;
         return $this;
+    }
+
+    public function typecast(bool $typecast = true): self
+    {
+      $this->typecast = $typecast;
+      return $this;
     }
 
     public function execute(): Recordset
@@ -25,7 +33,7 @@ class InsertQuery extends AbstractQuery
             throw new Errors\RecordsNotSpecified('At least one record must be specified');
         }
 
-        $data = ['records' => []];
+        $data = ['records' => [], 'typecast' => $this->typecast];
         foreach ($this->records as $record) {
             $data['records'][] = [
                 'fields' => $record->getFields()

--- a/src/Airtable/Query/UpdateQuery.php
+++ b/src/Airtable/Query/UpdateQuery.php
@@ -13,10 +13,18 @@ class UpdateQuery extends AbstractQuery
     /** @var Record[] */
     protected array $records = [];
 
+    protected bool $typecast = false;
+
     public function update(Record ...$records): self
     {
         $this->records = $records;
         return $this;
+    }
+
+    public function typecast(bool $typecast = true): self
+    {
+      $this->typecast = $typecast;
+      return $this;
     }
 
     public function execute(): Recordset
@@ -25,7 +33,7 @@ class UpdateQuery extends AbstractQuery
             throw new Errors\RecordsNotSpecified('At least one record must be specified');
         }
 
-        $data = ['records' => []];
+        $data = ['records' => [], 'typecast' => $this->typecast];
         foreach ($this->records as $record) {
             $data['records'][] = [
                 'id' => $record->getId(),


### PR DESCRIPTION
Thanks for the great package. While trying to insert a row that links to data in another record, I came across the need for the `typecast` parameter, which tries its best to match string data to the corresponding record ID. It works great for basic use-cases. 

This PR adds a `typecast()` parameter to the `insert()` query, which accepts a boolean and defaults to `true` if left empty. I was going to add a test for this, but I wasn't sure how to retrieve the id of the related data, which is what gets returned upon a successful insert.

Thanks for your consideration!